### PR TITLE
feat: add skills for git-add-account

### DIFF
--- a/.github/skills/git-add-account/SKILL.md
+++ b/.github/skills/git-add-account/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: git-add-account
+description: Adds a new SSH Git account, enabling automatic switching between multiple accounts based on the workspace. Use when setting up Git accounts, configuring SSH keys for different Git providers, or managing separate credentials for multiple projects.
+---
+
+# Git Add Account
+
+This skill adds a new SSH Git account tied to a specific workspace directory. Configures per-workspace Git and SSH settings so Git automatically uses the right identity based on where you run commands.
+
+## Usage
+
+> [!IMPORTANT]
+> Before proceeding, ensure npm, pnpm, yarn, bun or another Node.js compatible package manager is installed.
+> All file paths should be absolute, relative paths should be converted to absolute paths before proceeding.
+
+1. Using an available package manager, execute `@savaryna/git-add-account --help` to see all available options (e.g., `npx @savaryna/git-add-account --help`)
+2. Ask the user if they would like to run a dry run first
+3. Run `@savaryna/git-add-account` with the required parameters in non-interactive mode. For example:
+
+```bash
+npx @savaryna/git-add-account \
+  --non-interactive \
+  --name "Joe Doe" \
+  --email "joe@example.com" \
+  --host "github.com" \
+  --workspace "/Users/joe/code/personal" \
+  --signYourWork \
+  --dry-run
+```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 🔐 A small CLI app that allows you to easily add multiple Git accounts on one machine. It switches between accounts automatically based on the workspace you are in.
 
+## Agent usage (skill)
+
+Add the skill using
+
+```shell
+npx skills add savaryna/git-add-account
+```
+
+and ask your agent to "add a new git account".
+
 ## CLI usage
 
 Run the command direcly with

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -10,10 +10,36 @@ export default {
   command: ['$0', 'add'],
   describe: 'Add a new Git account',
   builder: (y) =>
-    y.option('dry-run', {
-      type: 'boolean',
-      describe: 'Preview the generated config files without writing them to disk',
-    }),
+    y
+      .option('name', {
+        type: 'string',
+        describe: 'Full name for Git commits (e.g., John Doe)',
+      })
+      .option('email', {
+        type: 'string',
+        describe: 'Email for this Git account',
+      })
+      .option('host', {
+        type: 'string',
+        describe: 'Git provider host (e.g., github.com, gitlab.com)',
+      })
+      .option('workspace', {
+        type: 'string',
+        describe: 'Absolute path to the workspace for this account',
+      })
+      .option('signYourWork', {
+        type: 'boolean',
+        describe: 'Sign commits and tags with your SSH key',
+        default: true,
+      })
+      .option('non-interactive', {
+        type: 'boolean',
+        describe: 'Run in non-interactive mode, all required options must be provided',
+      })
+      .option('dry-run', {
+        type: 'boolean',
+        describe: 'Preview the generated config files without writing them to disk',
+      }),
   handler: async (args) => {
     console.log("Let's add a new Git account.");
 
@@ -59,6 +85,13 @@ export default {
         throw new Error('Operation cancelled by the user.');
       },
     };
+
+    if (args?.nonInteractive) {
+      const errors = validate(ConfigDetails, args);
+      if (errors) throw new Error(errors);
+    }
+
+    prompts.override(args);
 
     const configDetails = (await prompts(questions, options)) as ConfigDetails;
     const configs = await getConfigs(configDetails);

--- a/src/helpers/validate.ts
+++ b/src/helpers/validate.ts
@@ -2,7 +2,12 @@ import type { ZodTypeAny } from 'zod';
 
 const validate = (schema: ZodTypeAny, data: unknown) => {
   const { success, error } = schema.safeParse(data);
-  return !success && error.errors.map(({ message }) => message).join('\n');
+  return (
+    !success &&
+    error.errors
+      .map(({ path, message }) => (path.length ? `${path}: ${message}` : message))
+      .join('\n')
+  );
 };
 
 export { z } from 'zod';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import commands from '@/commands';
 
 yargs(hideBin(process.argv))
   .scriptName('git-add-account')
-  .usage('$0 [cmd] <options>')
+  .usage('$0 <command> [options]')
   .command(commands)
   .demandCommand(0, 1)
   .help('h')


### PR DESCRIPTION
- Add non-interactive mode support in add command
- Update validation to include path for non-interactive mode
- Add skill metadata for git-add-account